### PR TITLE
Stop requiring an id for computeds and observables (BREAKING)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,17 +33,13 @@ import { observable, computed } from "@dependable/state";
 
 Then we can declare an observable for our todos.
 
-All of our observables and computeds needs to be uniquely named, to support debugging and enabling development tools.
-
 ```js
-const todos = observable("todos", []);
+const todos = observable([]);
 ```
 
 We will be putting todos inside of the `todos` observable, so let's define a class for a todo.
 
 As you can see, we defined `title` and `completed` as observables, as those fields are allowed to be updated.
-
-We give each todo a unique id and use that to produce a unique key for the observables.
 
 ```js
 let nextId = 0;
@@ -52,8 +48,8 @@ class Todo {
   constructor(title) {
     this.id = nextId++;
     const key = `todo.${this.id}`;
-    this.title = observable(`${key}.title`, title);
-    this.completed = observable(`${key}.completed`, false);
+    this.title = observable(title);
+    this.completed = observable(false);
   }
 }
 ```
@@ -69,15 +65,13 @@ const compareByTitle = (a, b) => {
   return 0;
 };
 
-const sortedTodos = computed("sortedTodos", () =>
-  todos().slice().sort(compareByTitle)
-);
+const sortedTodos = computed(() => todos().slice().sort(compareByTitle));
 ```
 
 Then we can create another todo, that filters out any completed todos.
 
 ```js
-const activeTodos = computed("activeTodos", () =>
+const activeTodos = computed(() =>
   sortedTodos().filter((todo) => !todo.completed())
 );
 ```
@@ -130,8 +124,8 @@ As you can see it is very easy to build something that is quite powerful.
 You can subscribe to both observables and computeds. Updates will be batched and each listener will only be called once for each batch. Listeners will only be called if the value we updated.
 
 ```js
-const message = observable("message", "");
-const aboveLimit = computed("aboveLimit", () => message().length > 140);
+const message = observable("");
+const aboveLimit = computed(() => message().length > 140);
 
 aboveLimit.subscribe(() => {
   if (aboveLimit()) {
@@ -147,11 +141,9 @@ By default observables and computeds compare values for equality using the `Obje
 In certain situations it is useful to override this comparison function, that can be done the following way.
 
 ```js
-const name = observable(
-  "name",
-  "Jane Doe",
-  (a, b) => a.toLowerCase() === b.toLowerCase()
-);
+const name = observable("Jane Doe", {
+  isEqual: (a, b) => a.toLowerCase() === b.toLowerCase(),
+});
 
 name.subscribe(() => {
   console.log(name());
@@ -167,8 +159,8 @@ name("John Doe");
 You can do the same for computeds like this.
 
 ```js
-const stuff = observable("stuff", []);
-const stuffById = computed("stuffById", () => {
+const stuff = observable([]);
+const stuffById = computed(() => {
   const result = new Map();
   for (const thing of stuff) {
     result.set(thing.id, thing);
@@ -205,8 +197,8 @@ We provide a `flush` method, for synchronously notifying any listeners, when you
 ```js
 import { flush } from "@dependable/state";
 
-const numbers = observable("numbers", []);
-const sum = computed("sum", () => numbers.reduce((sum, v) => sum + v, 0));
+const numbers = observable([]);
+const sum = computed(() => numbers.reduce((sum, v) => sum + v, 0));
 
 let notified = false;
 sum.subscribe(() => {

--- a/src/state.js
+++ b/src/state.js
@@ -26,7 +26,9 @@ export const subscribables = () => {
 };
 
 const registerActive = (fn) => {
-  dependableState._references.set(fn.id, new WeakRef(fn));
+  if (fn.id) {
+    dependableState._references.set(fn.id, new WeakRef(fn));
+  }
 
   notifyStateListeners(new Set([fn]));
 };
@@ -108,7 +110,7 @@ const registerUpdate = (fn) => {
   addFlushHook();
 };
 
-export const observable = (id, initialValue, isEqual = Object.is) => {
+export const observable = (initialValue, { id, isEqual = Object.is } = {}) => {
   let value = initialValue;
   let prevValue = initialValue;
 
@@ -173,7 +175,7 @@ const collectWork = (subscribables, work) => {
   }
 };
 
-export const computed = (id, cb, isEqual = Object.is) => {
+export const computed = (cb, { id, isEqual = Object.is } = {}) => {
   const listeners = new Set();
   let value = null;
   let prevValue = null;

--- a/test/computed.spec.js
+++ b/test/computed.spec.js
@@ -1,24 +1,28 @@
 import unexpected from "unexpected";
 import unexpectedSinon from "unexpected-sinon";
+import unexpectedDependable from "./unexpected-dependable.js";
 import sinon from "sinon";
 import { observable, computed, flush } from "../src/state.js";
 
-const expect = unexpected.clone().use(unexpectedSinon);
+const expect = unexpected
+  .clone()
+  .use(unexpectedSinon)
+  .use(unexpectedDependable);
 
 describe("computed", () => {
   it("creates a computed", () => {
-    const name = observable("name", "Jane Doe");
+    const name = observable("Jane Doe");
 
-    const greeting = computed("greeting", () => `Hello, ${name()}`);
+    const greeting = computed(() => `Hello, ${name()}`);
 
     expect(greeting.isComputed, "to be true");
   });
 
   describe("when not subscribed", () => {
     it("the value is still readable", () => {
-      const name = observable("name", "Jane Doe");
+      const name = observable("Jane Doe");
 
-      const greeting = computed("greeting", () => `Hello, ${name()}`);
+      const greeting = computed(() => `Hello, ${name()}`);
 
       expect(greeting(), "to equal", "Hello, Jane Doe");
     });
@@ -29,9 +33,9 @@ describe("computed", () => {
       let greeting, subscriptionSpy;
 
       beforeEach(() => {
-        const name = observable("name", "Jane Doe");
+        const name = observable("Jane Doe");
 
-        greeting = computed("greeting", () => `Hello, ${name()}`);
+        greeting = computed(() => `Hello, ${name()}`);
 
         subscriptionSpy = sinon.spy();
         greeting.subscribe(subscriptionSpy);
@@ -56,9 +60,9 @@ describe("computed", () => {
       let greeting, subscriptionSpy;
 
       beforeEach(() => {
-        const name = observable("name", "Jane Doe");
+        const name = observable("Jane Doe");
 
-        greeting = computed("greeting", () => `Hello, ${name()}`);
+        greeting = computed(() => `Hello, ${name()}`);
 
         subscriptionSpy = sinon.spy();
         greeting.subscribe(subscriptionSpy);
@@ -81,13 +85,11 @@ describe("computed", () => {
       let greeting, subscriptionSpy;
 
       beforeEach(() => {
-        const name = observable("name", "Jane Doe");
+        const name = observable("Jane Doe");
 
-        greeting = computed(
-          "greeting",
-          () => `Hello, ${name()}`,
-          (a, b) => a.toLowerCase() === b.toLowerCase()
-        );
+        greeting = computed(() => `Hello, ${name()}`, {
+          isEqual: (a, b) => a.toLowerCase() === b.toLowerCase(),
+        });
 
         subscriptionSpy = sinon.spy();
         greeting.subscribe(subscriptionSpy);
@@ -114,19 +116,19 @@ describe("computed", () => {
     let a, b;
 
     beforeEach(() => {
-      a = observable("a", 0);
-      b = observable("b", 0);
+      a = observable(0);
+      b = observable(0);
 
       sumSpy = sinon.spy(() => a() + b()).named("sum");
-      const sum = computed("sum", sumSpy);
+      const sum = computed(sumSpy);
       productSpy = sinon.spy(() => a() * b()).named("product");
-      const product = computed("product", productSpy);
+      const product = computed(productSpy);
 
       outputSpy = sinon
         .spy(() => `a: ${a()}, b: ${b()}, sum: ${sum()}, product: ${product()}`)
         .named("output");
 
-      output = computed("output", outputSpy);
+      output = computed(outputSpy);
 
       sumSubscriptionSpy = sinon.spy().named("sumSubscription");
       sum.subscribe(sumSubscriptionSpy);
@@ -232,12 +234,12 @@ describe("computed", () => {
     let computedSpy;
 
     beforeEach(() => {
-      choice = observable("choice", "a");
-      a = observable("a", "a");
-      b = observable("b", "b");
-      c = observable("c", "c");
+      choice = observable("a");
+      a = observable("a");
+      b = observable("b");
+      c = observable("c");
 
-      conditional = computed("conditional", () => {
+      conditional = computed(() => {
         switch (choice()) {
           case "a":
             return a();

--- a/test/example.spec.js
+++ b/test/example.spec.js
@@ -4,7 +4,7 @@ import unexpectedDependable from "./unexpected-dependable.js";
 
 const expect = unexpected.clone().use(unexpectedDependable);
 
-const todos = observable("todos", []);
+const todos = observable([]);
 
 let nextId = 0;
 
@@ -12,8 +12,8 @@ class Todo {
   constructor(title) {
     this.id = nextId++;
     const key = `todo.${this.id}`;
-    this.title = observable(`${key}.title`, title);
-    this.completed = observable(`${key}.completed`, false);
+    this.title = observable(title);
+    this.completed = observable(false);
   }
 }
 
@@ -33,11 +33,9 @@ const compareByTitle = (a, b) => {
   return 0;
 };
 
-const sortedTodos = computed("sortedTodos", () =>
-  todos().slice().sort(compareByTitle)
-);
+const sortedTodos = computed(() => todos().slice().sort(compareByTitle));
 
-const activeTodos = computed("activeTodos", () =>
+const activeTodos = computed(() =>
   sortedTodos().filter((todo) => !todo.completed())
 );
 

--- a/test/observables.spec.js
+++ b/test/observables.spec.js
@@ -1,23 +1,27 @@
 import unexpected from "unexpected";
 import unexpectedSinon from "unexpected-sinon";
+import unexpectedDependable from "./unexpected-dependable.js";
 import sinon from "sinon";
 import { observable, flush } from "../src/state.js";
 import { FakePromise } from "fake-promise";
 
-const expect = unexpected.clone().use(unexpectedSinon);
+const expect = unexpected
+  .clone()
+  .use(unexpectedSinon)
+  .use(unexpectedDependable);
 
 const tick = () => new Promise((resolve) => setImmediate(resolve));
 
 describe("observable", () => {
   it("returns the initial value when it hasn't been updated", () => {
-    const v = observable("v", "foo");
+    const v = observable("foo");
 
     expect(v(), "to equal", "foo");
   });
 
   describe("when updating the value", () => {
     it("updates the value", () => {
-      const v = observable("v", "foo");
+      const v = observable("foo");
 
       v("bar");
 
@@ -27,7 +31,7 @@ describe("observable", () => {
 
   describe("subscribe", () => {
     it("notifies it's subscribers on updates", () => {
-      const v = observable("v", "foo");
+      const v = observable("foo");
 
       const subscriptionSpy = sinon.spy();
       v.subscribe(subscriptionSpy);
@@ -44,7 +48,7 @@ describe("observable", () => {
     });
 
     it("doesn't notify if the value hasn't changed", () => {
-      const v = observable("v", "foo");
+      const v = observable("foo");
 
       const subscriptionSpy = sinon.spy();
       v.subscribe(subscriptionSpy);
@@ -60,9 +64,8 @@ describe("observable", () => {
 
     it("doesn't notify if the value hasn't changed, according to the given equal function", () => {
       const v = observable(
-        "v",
         { id: 0, value: "foo" },
-        (a, b) => a.id === b.id
+        { isEqual: (a, b) => a.id === b.id }
       );
 
       const subscriptionSpy = sinon.spy();
@@ -80,7 +83,7 @@ describe("observable", () => {
 
   describe("unsubscribe", () => {
     it("doesn't notify on updates", () => {
-      const v = observable("v", "foo");
+      const v = observable("foo");
 
       const subscriptionSpy = sinon.spy();
 
@@ -99,8 +102,8 @@ describe("observable", () => {
 
   describe("when updating multiple observables", () => {
     it("only notifies each subscriber once", () => {
-      const v1 = observable("v1", "v1");
-      const v2 = observable("v2", "v2");
+      const v1 = observable("v1");
+      const v2 = observable("v2");
 
       const subscriptionSpy = sinon.spy();
       v1.subscribe(subscriptionSpy);
@@ -121,8 +124,8 @@ describe("observable", () => {
 
     describe("with async updates", () => {
       it("submit updates in batches", async () => {
-        const v1 = observable("v1", "v1");
-        const v2 = observable("v2", "v2");
+        const v1 = observable("v1");
+        const v2 = observable("v2");
 
         const subscriptionSpy = sinon.spy();
         v1.subscribe(subscriptionSpy);

--- a/test/stateListener.spec.js
+++ b/test/stateListener.spec.js
@@ -1,5 +1,6 @@
 import unexpected from "unexpected";
 import unexpectedSinon from "unexpected-sinon";
+import unexpectedDependable from "./unexpected-dependable.js";
 import sinon from "sinon";
 import { FakePromise } from "fake-promise";
 import {
@@ -10,7 +11,10 @@ import {
   subscribables,
 } from "../src/state.js";
 
-const expect = unexpected.clone().use(unexpectedSinon);
+const expect = unexpected
+  .clone()
+  .use(unexpectedSinon)
+  .use(unexpectedDependable);
 
 const tick = () => new Promise((resolve) => setImmediate(resolve));
 
@@ -20,10 +24,12 @@ describe("stateListener", () => {
     // Make sure other tests doesn't have registered references
     global.__dependable._references = new Map();
 
-    firstName = observable("firstName", "John");
-    lastName = observable("lastName", "Doe");
+    firstName = observable("John", { id: "firstName" });
+    lastName = observable("Doe", { id: "lastName" });
 
-    fullName = computed("fullName", () => `${firstName()} ${lastName()}`);
+    fullName = computed(() => `${firstName()} ${lastName()}`, {
+      id: "fullName",
+    });
   });
 
   describe("subscribables", () => {
@@ -63,7 +69,7 @@ describe("stateListener", () => {
       let newObservable;
 
       beforeEach(() => {
-        newObservable = observable("new", "this is new");
+        newObservable = observable("this is new", { id: "new" });
       });
 
       it("will be included in the working set", () => {

--- a/test/unexpected-dependable.js
+++ b/test/unexpected-dependable.js
@@ -10,11 +10,15 @@ export default {
       unwrap: function (observable) {
         return observable();
       },
-      prefix: function (output, value) {
-        return output.code("observable('").jsString(value.id).code("', ");
+      prefix: function (output) {
+        return output.code("observable(");
       },
-      suffix: function (output) {
-        return output.code(")");
+      suffix: function (output, value) {
+        if (value.id) {
+          output.code(", { id: '").jsString(value.id).code("' }");
+        }
+        output.code(")");
+        return output;
       },
     });
 
@@ -25,7 +29,7 @@ export default {
         return value && value.isComputed;
       },
       prefix: function (output, value) {
-        return output.code("computed('").jsString(value.id).code("', ");
+        return output.code("computed(");
       },
     });
   },


### PR DESCRIPTION
The devtools package will document how do support inspection and revival, but it is no longer required.

You now set the `id` and the `isEqual` in the options object for both computeds and observables:

```js
const foo = observable('FOO', { id: 'foo', isEqual: (a, b) => a.toLowerCase() === b.toLowerCase() });
```