### PR TITLE
Flush subscriber updates in same batch

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -93,15 +93,20 @@ export const flush = () => {
     }
   }
 
+  dependableState._updated.clear();
+
   for (const listener of listeners) {
     listener();
   }
 
   notifyStateListeners(updates);
 
-  dependableState._updated.clear();
-
   clearFlushHook();
+
+  if (dependableState._updated.size > 0) {
+    // subscriptions made new updates
+    flush();
+  }
 };
 
 const registerUpdate = (fn) => {

--- a/test/observables.spec.js
+++ b/test/observables.spec.js
@@ -47,6 +47,37 @@ describe("observable", () => {
       });
     });
 
+    describe("when the subscribe makes a new update", () => {
+      it("is excuted in the same batch", () => {
+        const foo = observable("foo");
+        const bar = observable("bar");
+        const qux = observable("qux");
+
+        foo.subscribe(() => {
+          bar(foo());
+        });
+
+        bar.subscribe(() => {
+          qux(bar());
+        });
+
+        const subscriptionSpy = sinon.spy();
+        qux.subscribe(subscriptionSpy);
+
+        foo("updated");
+
+        flush();
+
+        expect(foo(), "to equal", "updated");
+        expect(bar(), "to equal", "updated");
+        expect(qux(), "to equal", "updated");
+
+        expect(subscriptionSpy, "to have calls satisfying", () => {
+          subscriptionSpy();
+        });
+      });
+    });
+
     it("doesn't notify if the value hasn't changed", () => {
       const v = observable("foo");
 


### PR DESCRIPTION
If a subscription updates an observable, we flush those changes in the
same batch.