### PR TITLE
Allow to specify the priority of a subscriber

### DIFF
--- a/src/shared.d.ts
+++ b/src/shared.d.ts
@@ -29,8 +29,11 @@ export interface Subscribable {
    * Add the given subscriber to this subscribable.
    *
    * @param subscriber the subscriber that should be added
+   * @param priority the priority of this subscriber; lower numbers takes precedence.
+   *
+   * Defaults to zero.
    */
-  subscribe(subscriber: Subscriber): void;
+  subscribe(subscriber: Subscriber, priority?: number): void;
   /**
    * Remove the given subscriber to this subscribable.
    *

--- a/test/observables.spec.js
+++ b/test/observables.spec.js
@@ -48,6 +48,36 @@ describe("observable", () => {
       });
     });
 
+    describe("when given a priority", () => {
+      it("lower numbers takes precedence", () => {
+        const v = observable("foo");
+
+        const priority0Spy = sinon.spy();
+        const priority10Spy = sinon.spy();
+        const priority100Spy = sinon.spy();
+
+        v.subscribe(priority100Spy, 100);
+        v.subscribe(priority0Spy);
+        v.subscribe(priority10Spy, 10);
+
+        v("bar");
+
+        flush();
+
+        expect(v(), "to equal", "bar");
+
+        expect(
+          [priority0Spy, priority10Spy, priority100Spy],
+          "to have calls satisfying",
+          () => {
+            priority0Spy();
+            priority10Spy();
+            priority100Spy();
+          }
+        );
+      });
+    });
+
     describe("when the subscribe makes a new update", () => {
       it("is excuted in the same batch", () => {
         const foo = observable("foo");


### PR DESCRIPTION
The priority default to zero and lower numbers takes precedence.