### PR TITLE
Remove isEqual from observables (Major)

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,56 +137,38 @@ aboveLimit.subscribe(() => {
 });
 ```
 
-## Overriding equality comparison
+## Overriding equality comparison for computeds
 
-By default observables and computeds compare values for equality using the `Object.is` function. The library uses this function to figure out if an observable or computed has changed is value and therefore should notify isn't subscribers.
+By default computeds compare values for equality using the `Object.is` function. The library uses this function to figure out if a computed has changed is value and therefore should notify it's subscribers.
 
 In certain situations it is useful to override this comparison function, that can be done the following way.
 
 ```js
-const name = observable("Jane Doe", {
-  isEqual: (a, b) => a.toLowerCase() === b.toLowerCase(),
+const numbers = observable([1, 3, 0, 2]);
+
+const arrayIsEquals = (a, b) => {
+  if (a.length !== b.length) return false;
+
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+
+  return true;
+};
+
+const sortedNumbers = computed(() => numbers().slice().sort(), {
+  isEqual: arrayIsEquals,
 });
 
-name.subscribe(() => {
-  console.log(name());
+numbers.subscribe(() => {
+  console.log(numbers());
 });
 
 // This doesn't trigger the subscription
-name("JANE DOE");
+numbers([1, 2, 3, 0]);
 
 // but this does
-name("John Doe");
-```
-
-You can do the same for computeds like this.
-
-```js
-const stuff = observable([]);
-const stuffById = computed(() => {
-  const result = new Map();
-  for (const thing of stuff) {
-    result.set(thing.id, thing);
-  }
-  return result;
-});
-
-const stuffWithId = (id) =>
-  computed(() => stuff().find((item) => item.id === id), {
-    isEqual: (a, b) => a.id === b.id,
-  });
-
-const foo = stuffWithId("foo");
-
-foo.subscribe(() => {
-  console.log(foo);
-});
-
-// trigger an update to foo
-stuff([{ id: "foo" }]);
-
-// doesn't trigger another update to foo
-stuff([{ id: "foo" }, { id: "bar" }]);
+numbers([1, 2, 3, 0, 4]);
 ```
 
 ## Testing

--- a/src/shared.d.ts
+++ b/src/shared.d.ts
@@ -91,19 +91,27 @@ export type Equality<T> = {
  *
  * @template T the type subscribable value.
  */
-export type SubscribableOptions<T> = {
+export type SubscribableOptions = {
   /**
    * The id of the subscribable.
    *
    * Used for debugging and development tools.
    */
   id?: string;
+};
+
+/**
+ * Options for a subscribable.
+ *
+ * @template T the type subscribable value.
+ */
+export type ComputedOptions<T> = Subscribable & {
 
   /**
    * A function deciding if the value of the subscribable has changed.
    */
   isEqual?: Equality<T>;
-};
+}
 
 /**
  * The set of active subscribables.

--- a/src/state.js
+++ b/src/state.js
@@ -159,19 +159,15 @@ const registerUpdate = (fn) => {
  *
  * @template T
  * @param {T} initialValue Initial value
- * @param {import('./shared').SubscribableOptions<T>} options Subscribable options
+ * @param {import('./shared').SubscribableOptions} options Subscribable options
  * @returns {import('./shared').Observable<T>} Observable
  */
 export const observable = (initialValue, options = {}) => {
-  const { id, isEqual = Object.is } = options;
+  const { id } = options;
 
   if (id && dependableState._initial.has(id)) {
     const restored = dependableState._initial.get(id);
     if (restored) {
-      // override isEqual as it might not have been set
-      // and restoring observables will be initialized without it.
-      restored._isEqual = isEqual;
-
       // has been restored
       dependableState._initial.delete(id);
       return restored;
@@ -196,17 +192,13 @@ export const observable = (initialValue, options = {}) => {
     } else {
       prevValue = value;
       value = args[0];
-      fn._hasChanged = !fn._isEqual(value, prevValue);
-
-      if (fn._hasChanged) {
-        registerUpdate(fn);
-      }
+      fn._hasChanged = true;
+      registerUpdate(fn);
     }
   };
 
   fn.id = id;
   fn.kind = "observable";
-  fn._isEqual = isEqual;
   fn._dependents = new Set();
   fn._subscribers = new Map();
   fn._hasChanged = false;
@@ -262,7 +254,7 @@ export const track = (cb) => {
  *
  * @template T
  * @param {() => T} cb Function that produces the computed result
- * @param {import('./shared').SubscribableOptions<T>} options Subscribable options
+ * @param {import('./shared').ComputedOptions<T>} options Subscribable options
  * @returns {import('./shared').Computed<T>} Computed
  */
 export const computed = (cb, options = {}) => {

--- a/test/computed.spec.js
+++ b/test/computed.spec.js
@@ -144,7 +144,7 @@ describe("computed", () => {
 
         flush();
 
-        // Shouldn't trigger any updates
+        // Should only change the output
         a(4);
         b(2);
 
@@ -189,6 +189,11 @@ describe("computed", () => {
             productSpy();
 
             // When a=4 b=2
+            sumSpy();
+            productSpy();
+            outputSpy();
+
+            // When a=4 b=2 again
             sumSpy();
             productSpy();
             outputSpy();

--- a/test/observables.spec.js
+++ b/test/observables.spec.js
@@ -109,7 +109,7 @@ describe("observable", () => {
       });
     });
 
-    it("doesn't notify if the value hasn't changed", () => {
+    it("notify even if the value hasn't changed", () => {
       const v = observable("foo");
 
       const subscriptionSpy = sinon.spy();
@@ -121,25 +121,9 @@ describe("observable", () => {
 
       expect(v(), "to equal", "foo");
 
-      expect(subscriptionSpy, "was not called");
-    });
-
-    it("doesn't notify if the value hasn't changed, according to the given equal function", () => {
-      const v = observable(
-        { id: 0, value: "foo" },
-        { isEqual: (a, b) => a.id === b.id }
-      );
-
-      const subscriptionSpy = sinon.spy();
-      v.subscribe(subscriptionSpy);
-
-      v({ id: 0, value: "foo" });
-
-      flush();
-
-      expect(v(), "to equal", { id: 0, value: "foo" });
-
-      expect(subscriptionSpy, "was not called");
+      expect(subscriptionSpy, "to have calls satisfying", () => {
+        subscriptionSpy();
+      });
     });
   });
 


### PR DESCRIPTION
This is breaking and means that updates to observables will always
trigger an update. This is necessary as `isEqual` isn't serializable and
will prevent restoring observables. So if you don't want to trigger a
new update, you should compare the values before updating.