### PR TITLE
Set a default id on all subscribables

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 Observables and computeds for reactive state management
 
 - Easy learning curve
-- Tiny, less than 1kb
 - Zero dependencies
 - Allows multiple versions of the library in the page
 - Batches updates

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -16,6 +16,7 @@ const minifyPlugins = [
           $_dependents: "f",
           $_registerDependent: "g",
           $_unregisterDependent: "h",
+          $_nextId: "i",
         },
       },
     },

--- a/src/shared.d.ts
+++ b/src/shared.d.ts
@@ -20,7 +20,7 @@ export interface Subscribable {
   /**
    * The id of the subscribable.
    */
-  id: string | null;
+  id: string;
   /**
    * The kind of subscribable.
    */

--- a/src/state.js
+++ b/src/state.js
@@ -3,6 +3,7 @@ const dependableState = globalThis.__dependable || {};
 if (!globalThis.__dependable) {
   globalThis.__dependable = dependableState;
 
+  dependableState._nextId = 0;
   dependableState._updated = new Set();
   dependableState._references = new Map();
   dependableState._listeners = new Set();
@@ -10,6 +11,8 @@ if (!globalThis.__dependable) {
 }
 
 const defaultPriority = 0;
+
+const nextId = () => "$" + dependableState._nextId++;
 
 /**
  * Add a state listener.
@@ -167,7 +170,7 @@ const registerUpdate = (fn) => {
  * @returns {import('./shared').Observable<T>} Observable
  */
 export const observable = (initialValue, options = {}) => {
-  const { id } = options;
+  const { id = nextId() } = options;
 
   if (id && dependableState._initial.has(id)) {
     const restored = dependableState._initial.get(id);
@@ -262,7 +265,7 @@ export const track = (cb) => {
  * @returns {import('./shared').Computed<T>} Computed
  */
 export const computed = (cb, options = {}) => {
-  const { id, isEqual = Object.is } = options;
+  const { id = nextId(), isEqual = Object.is } = options;
 
   if (id && dependableState._references.has(id)) {
     let cached = dependableState._references.get(id).deref();


### PR DESCRIPTION
Notice will break compatibility as the `id` field on subscribables will be populated automatically. 