### PR TITLE
Stop reusing cached observables with same id

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -174,11 +174,6 @@ export const observable = (initialValue, options = {}) => {
     return restored;
   }
 
-  if (id && dependableState._references.has(id)) {
-    const cached = dependableState._references.get(id).deref();
-    if (cached) return cached;
-  }
-
   let value = initialValue;
   let prevValue = initialValue;
 
@@ -259,11 +254,6 @@ export const track = (cb) => {
  */
 export const computed = (cb, options = {}) => {
   const { id, isEqual = Object.is } = options;
-
-  if (id && dependableState._references.has(id)) {
-    let cached = dependableState._references.get(id).deref();
-    if (cached) return cached;
-  }
 
   let value = null;
   let prevValue = null;

--- a/test/stateListener.spec.js
+++ b/test/stateListener.spec.js
@@ -32,24 +32,6 @@ describe("stateListener", () => {
     });
   });
 
-  describe("when initializing an observable with an existing id", () => {
-    it("returns the previous observable", () => {
-      const anotherFirstName = observable("Jane", { id: "firstName" });
-
-      expect(firstName, "to be", anotherFirstName);
-    });
-  });
-
-  describe("when initializing an computed with an existing id", () => {
-    it("returns the previous computed", () => {
-      const anotherFullName = computed(() => `${lastName()}, ${firstName()}`, {
-        id: "fullName",
-      });
-
-      expect(fullName, "to be", anotherFullName);
-    });
-  });
-
   describe("subscribables", () => {
     it("returns the current subscribables", () => {
       expect(


### PR DESCRIPTION
This kind of reuse of the cached observables is causing too many problems, so I'll remove it.

This will break `@dependable/session` so I'll also fix that.