### PR TITLE
Also name _subscribers when mangling

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -16,6 +16,7 @@ const minifyPlugins = [
           $_dependents: "f",
           $_registerDependent: "g",
           $_unregisterDependent: "h",
+          $_subscribers: "i",
         },
       },
     },


### PR DESCRIPTION
This is just to allow internal integrations with private state.